### PR TITLE
  - 0.3.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+  - 0.3.2
+    - support for command prefixes, most notabably **xvfb-run** to let a
+      wkhtmltopdf which was compiled without an unpatched version of qt run on
+      machines without an x server
+    - (add in precompiled, patched binaries for wkhtmltopdf and libjpeg8 that are
+      needed to run wkhtmltopdf without xvfb-run)
   - 0.3.1
     - implement this as proper application, look for executables at startup (and possibly fail on that)
     - save paths in a PfdGenerator.Agent

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 A simple wrapper for wkhtmltopdf (HTML to PDF) and PDFTK (adds in encryption) for use in Elixir projects.
 It is currently using temporary files instead of pipes or other means of IPC.
 
-# New in 0.3.1
+# New in 0.3.2
 
- - 0.3.1
-    - implement this as proper application, look for executables at startup (and possibly fail on that)
-    - save paths in a PfdGenerator.Agent
-    - make paths configurable in `config/ENV.exs` as well
-    - add some tests (Yay!)
-    - better README
+  - 0.3.2
+    - support for command prefixes, most notabably **xvfb-run** to let a
+      wkhtmltopdf which was compiled without an unpatched version of qt run on
+      machines without an x server
+    - (add in precompiled, patched binaries for wkhtmltopdf and libjpeg8 that are
+      needed to run wkhtmltopdf without xvfb-run)
 
 For a proper changelog, see [CHANGES](CHANGES.md)
 
@@ -53,19 +53,24 @@ html = "<html><body><p>Hi there!</p></body></html>"
 
 # Configuration
 
-This module will automatically try to finde both `wkhtmltopdf` and `pdftk` in your path. But you may override or explicitly set their paths in your config/config.exs:
+This module will automatically try to finde both `wkhtmltopdf` and `pdftk` in
+your path. But you may override or explicitly set their paths in your
+config/config.exs:
 
 ```
 config :pdf_generator,
-      wkhtml_path: "/path/to/wkhtmltopdf",
-      pdftk_path:  "/path/to/pdftk",
+    wkhtml_path:    "/usr/bin/wkhtmltopdf",
+    pdftk_path:     "/usr/bin/pdftk",
+    command_prefix: "xvfb-run"
 ```
 
 # Documentation
 
-For more info, read the [docs on hex](http://hexdocs.pm/pdf_generator) or issue `h PdfGenerator` in your iex shell.
+For more info, read the [docs on hex](http://hexdocs.pm/pdf_generator) or issue
+`h PdfGenerator` in your iex shell.
 
 TODO
 ====
 
-- [ ] Pass some useful base path so wkhtmltopdf can resolve static files (styles, images etc) linked in the HTML
+- [ ] Pass some useful base path so wkhtmltopdf can resolve static files
+  (styles, images etc) linked in the HTML

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,24 +1,9 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for third-
-# party users, it should be done in your mix.exs file.
+# config :pdf_generator,
+#   wkhtml_path: "/usr/bin/wkhtmltopdf",
+#   pdftk_path:  "/usr/bin/pdftk",
+#   command_prefix:   "/usr/bin/xvfb-run"
 
-# Sample configuration:
-#
-#     config :logger, :console,
-#       level: :info,
-#       format: "$date $time [$level] $metadata$message\n",
-#       metadata: [:user_id]
+import_config "#{Mix.env}.exs"
 
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,2 @@
+use Mix.Config
+

--- a/config/pros.exs
+++ b/config/pros.exs
@@ -1,0 +1,2 @@
+use Mix.Config
+

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,6 @@
+use Mix.Config
+
+config :pdf_generator,
+  command_prefix: "xvfb-run"
+
+

--- a/lib/pdf_generator_path_agent.ex
+++ b/lib/pdf_generator_path_agent.ex
@@ -18,8 +18,9 @@ defmodule PdfGenerator.PathAgent do
     # options override system default paths
     options = 
       [
-        wkhtml_path: System.find_executable( "wkhtmltopdf" ),
-        pdftk_path: System.find_executable( "pdftk" ),
+        wkhtml_path:    System.find_executable( "wkhtmltopdf" ),
+        pdftk_path:     System.find_executable( "pdftk" ),
+        # command_prefix: System.find_executable( "xvfb-run" )
       ] 
       ++ paths_from_options
       |> Enum.filter( fn { _, v } -> v != nil end ) 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule PdfGenerator.Mixfile do
     [
       app: :pdf_generator,
       name: "PDF Generator",
-      version: "0.3.1",
+      version: "0.3.2",
       elixir: ">= 1.0.0",
       deps: deps,
       description: description,
@@ -27,7 +27,7 @@ defmodule PdfGenerator.Mixfile do
 
   def description do
     """
-    A simple wrapper for wkhtmltopdf (HTML to PDF) and PDFTK (adds in encryption) for use in Elixir projects.
+    A wrapper for wkhtmltopdf (HTML to PDF) and PDFTK (adds in encryption) for use in Elixir projects.
     """ 
   end
 

--- a/test/pdf_generator_test.exs
+++ b/test/pdf_generator_test.exs
@@ -20,4 +20,8 @@ defmodule PdfGeneratorTest do
     assert String.slice( pdf, 0, 6) == "%PDF-1"
   end
 
+  test "command prefix with noop env" do
+    {:ok, temp_filename } = PdfGenerator.generate @html, [ command_prefix: "env" ]
+  end
+
 end


### PR DESCRIPTION
    - support for command prefixes, most notabably **xvfb-run** to let a
      wkhtmltopdf which was compiled without an unpatched version of qt run on
      machines without an x server
    - (add in precompiled, patched binaries for wkhtmltopdf and libjpeg8 that are
      needed to run wkhtmltopdf without xvfb-run)