### PR TITLE
add xvfb support via command_prefix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,13 @@
 # Changes
 
+  - 0.3.4
+    - BUGFIX: fix merge confusion to **realy** support `xvfb-run` or other
+      command prefixes to wkhtmltopdf
+    - support explicit deletion of temporary files thanks to
+      [Edipo Vinicius da Silva](https://github.com/edipox)
+    - Improve README
   - 0.3.3
-    -BUGFIX: typo in config/prod.exs
+    - BUGFIX: typo in config/prod.exs
   - 0.3.2
     - support for command prefixes, most notabably **xvfb-run** to let a
       wkhtmltopdf which was compiled without an unpatched version of qt run on
@@ -9,7 +15,8 @@
     - (add in precompiled, patched binaries for wkhtmltopdf and libjpeg8 that are
       needed to run wkhtmltopdf without xvfb-run)
   - 0.3.1
-    - implement this as proper application, look for executables at startup (and possibly fail on that)
+    - implement this as proper application, look for executables at startup (and
+      possibly fail on that)
     - save paths in a PfdGenerator.Agent
     - make paths configurable in `config/ENV.exs` as well
     - add some tests (Yay!)
@@ -17,6 +24,7 @@
 
   - 0.2.0 
     - adding support for PDFTK to create encrypted PDFs
-    - **API-CHANGE** PdfGenerator.generate now returns tuple `{ :ok, file_name }` instead of just `file_name`
+    - **API-CHANGE** PdfGenerator.generate now returns tuple `{:ok, file_name}`
+      instead of just `file_name`
     - Adding some docs, issue `h PdfGenerator` in your iex shell for more info
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ config :pdf_generator,
 - `open_password`:    requires `pdftk`, password to encrypt PDFs with
 - `edit_password`:    requires `pdftk`, sets password for edit permissions on PDF
 - `shell_params`:     pass custom parameters to wkhtmltopdf. **CAUTION: BEWARE OF SHELL INJECTIONS!** 
-- `command_prefix`:   see "Running headless" above
+- `command_prefix`:   prefix wkhtmltopdf with some command (e.g. `xvfb-run`, `sudo` ..)
 - `delete_temporary`: immediately remove temp files after generation
 
 # Documentation

--- a/README.md
+++ b/README.md
@@ -2,30 +2,37 @@
 
 A wrapper for wkhtmltopdf (HTML to PDF) and PDFTK (adds in encryption) for use in Elixir projects. If available, it will use xvfb-run (x virtual frame buffer) to use wkhtmltopdf on systems that have no X installed, e.g. a server.
 
-# New in 0.3.2 and 0.3.3
+# New in 0.3.4
 
-  - 0.3.3
-    -BUGFIX: typo in config/prod.exs
-  - 0.3.2
-    - support for command prefixes, most notably **xvfb-run** to let a
-      wkhtmltopdf which was compiled without an unpatched version of qt run on
-      machines without an x server
-    - (add in precompiled, patched binaries for wkhtmltopdf and libjpeg8 that are
-      needed to run wkhtmltopdf without xvfb-run)
+  - 0.3.4
+    - BUGFIX: fix merge confusion to **realy** support `xvfb-run` or other
+      command prefixes to wkhtmltopdf
+    - support explicit deletion of temporary files thanks to
+      [Edipo Vinicius da Silva](https://github.com/edipox)
+    - Improve README
 
 For a proper changelog, see [CHANGES](CHANGES.md)
 
+# System prerequisites
+
+Download wkhtmltopdf and place it in your $PATH. Current binaries can be found
+here: http://wkhtmltopdf.org/downloads.html
+
+_(optional)_ To use wkhtmltopdf on systems without an X window server installed,
+please install `xvfb-run` from your repository (on Debian/Ubuntu: `sudo apt-get
+install xvfb`).
+
+On current (2016) Macintosh computers `/usr/X11/bin/xvfb` should be available
+and is reported to do the same thing. _warning:_ This is untested. PLS report to
+me if you ran this successfully on a Mac.
+
+_(optional)_ For best results, download goon and place it in your $PATH. Current
+binaries can be found here: https://github.com/alco/goon/releases
+
+_(optional)_ Install pdftk (optional) via your package manager or homebrew. The
+project page also contains a Windows installer
+
 # Usage
-
-Download wkhtmltopdf and place it in your $PATH. Current binaries can be found here:
-http://wkhtmltopdf.org/downloads.html
-
-_(optional)_ To use wkhtmltopdf on systems without an X window server installed, please install `xvfb-run` from your repository or via `homebrew` (Mac)
-
-_(optional)_ For best results, download goon and place it in your $PATH. Current binaries can be found here:
-https://github.com/alco/goon/releases
-
-_(optional)_ Install pdftk (optional) via your package manager or homebrew. The project page also contains a Windows installer
 
 Add this to your dependencies in your mix.exs:
 
@@ -54,26 +61,45 @@ html = "<html><body><p>Hi there!</p></body></html>"
 { :ok, pdf_content } = File.read file_name 
 ```
 
-# Configuration
+# Options and Configuration
 
 This module will automatically try to finde both `wkhtmltopdf` and `pdftk` in
 your path. But you may override or explicitly set their paths in your
-config/config.exs:
+`config/config.exs`. 
 
 ```
 config :pdf_generator,
     wkhtml_path:    "/usr/bin/wkhtmltopdf",
-    pdftk_path:     "/usr/bin/pdftk",
-    command_prefix: "xvfb-run"
+    pdftk_path:     "/usr/bin/pdftk"
 ```
+
+## Running headless (server-mode)
+
+If you happen to want to run an wkhtmltopdf with an unpatched version of webkit
+that requires an X Window server - but on your server (or Mac) ain't one, you
+might find a `command_prefix` handy:
+
+```
+PdfGenerator.generate "<html..", command_prefix: "xvfb-run" 
+```
+
+This can also be configured globally in cour `config/config.exs`:
+
+```
+config :pdf_generator,
+    command_prefix: "/usr/bin/xvfb-run"
+```
+
+## More options
+ 
+- `page_size`:        defaults to `A4`, see wkhtmltopdf for more options 
+- `open_password`:    requires `pdftk`, password to encrypt PDFs with
+- `edit_password`:    requires `pdftk`, sets password for edit permissions on PDF
+- `shell_params`:     pass custom parameters to wkhtmltopdf. **CAUTION: BEWARE OF SHELL INJECTIONS!** 
+- `command_prefix`:   see "Running headless" above
+- `delete_temporary`: immediately remove temp files after generation
 
 # Documentation
 
 For more info, read the [docs on hex](http://hexdocs.pm/pdf_generator) or issue
 `h PdfGenerator` in your iex shell.
-
-TODO
-====
-
-- [ ] Pass some useful base path so wkhtmltopdf can resolve static files
-  (styles, images etc) linked in the HTML

--- a/lib/pdf_generator.ex
+++ b/lib/pdf_generator.ex
@@ -67,8 +67,9 @@ defmodule PdfGenerator do
         # worker(TestApp.Worker, [arg1, arg2, arg3])
         worker(
           PdfGenerator.PathAgent, [[
-            wkhtml_path: Application.get_env(:pdf_generator, :wkhtml_path ),
-            pdftk_path:  Application.get_env(:pdf_generator, :pdftk_path  ),
+            wkhtml_path:    Application.get_env(:pdf_generator, :wkhtml_path),
+            pdftk_path:     Application.get_env(:pdf_generator, :pdftk_path),
+            command_prefix: Application.get_env(:pdf_generator, :command_prefix),
           ]]
         )
       ]

--- a/lib/pdf_generator.ex
+++ b/lib/pdf_generator.ex
@@ -69,7 +69,6 @@ defmodule PdfGenerator do
           PdfGenerator.PathAgent, [[
             wkhtml_path:    Application.get_env(:pdf_generator, :wkhtml_path),
             pdftk_path:     Application.get_env(:pdf_generator, :pdftk_path),
-            command_prefix: Application.get_env(:pdf_generator, :command_prefix),
           ]]
         )
       ]
@@ -122,7 +121,7 @@ defmodule PdfGenerator do
 
     executable     = wkhtml_path
     arguments      = List.flatten( [ shell_params, html_file, pdf_file ] )
-    command_prefix = Keyword.get( options, :command_prefix ) || PdfGenerator.PathAgent.get |> Map.get( :command_prefix )
+    command_prefix = Keyword.get( options, :command_prefix ) || Application.get_env( :pdf_generator, :command_prefix )
 
     # allow for xvfb-run wkhtmltopdf arg1 arg2
     # or sudo wkhtmltopdf ...
@@ -157,8 +156,17 @@ defmodule PdfGenerator do
   def encrypt_pdf( pdf_input_path, user_pw, owner_pw ) do
     pdftk_path = PdfGenerator.PathAgent.get.pdftk_path
 
-    if owner_pw == nil, do: owner_pw = Misc.Random.string(16)
-    if user_pw  == nil, do: user_pw  = Misc.Random.string(16)
+    owner_pw =
+      case owner_pw do
+        nil -> Misc.Random.string(16)
+        _   -> owner_pw
+      end
+
+    user_pw =
+      case user_pw do
+        nil -> Misc.Random.string(16)
+        _   -> user_pw
+      end
 
     pdf_output_file  = Path.join System.tmp_dir, Misc.Random.string <> ".pdf"
 

--- a/lib/pdf_generator_path_agent.ex
+++ b/lib/pdf_generator_path_agent.ex
@@ -3,10 +3,10 @@ defmodule PdfGenerator.PathAgent do
   defstruct wkhtml_path: nil, pdftk_path: nil
 
   @moduledoc """
-  Will check system requirements on startup and keep 
+  Will check system requirements on startup and keep
   a path map as state in an Agent process.
   """
-  
+
   @name __MODULE__
 
   def start_link( path_options ) do
@@ -14,16 +14,14 @@ defmodule PdfGenerator.PathAgent do
   end
 
   def init_opts( paths_from_options ) do
-    
     # options override system default paths
-    options = 
+    options =
       [
         wkhtml_path:    System.find_executable( "wkhtmltopdf" ),
-        pdftk_path:     System.find_executable( "pdftk" ),
-        # command_prefix: System.find_executable( "xvfb-run" )
-      ] 
+        pdftk_path:     System.find_executable( "pdftk" )
+      ]
       ++ paths_from_options
-      |> Enum.filter( fn { _, v } -> v != nil end ) 
+      |> Enum.filter( fn { _, v } -> v != nil end )
 
     # at least, wkhtmltopdf executable sould be there
     if Keyword.fetch!( options, :wkhtml_path ) == nil do
@@ -44,5 +42,5 @@ defmodule PdfGenerator.PathAgent do
   def get do
     Agent.get( @name, fn( data ) -> data end )
   end
-  
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule PdfGenerator.Mixfile do
     [
       app: :pdf_generator,
       name: "PDF Generator",
-      version: "0.3.3",
+      version: "0.3.4",
       elixir: ">= 1.0.0",
       deps: deps,
       description: description,

--- a/test/pdf_generator_test.exs
+++ b/test/pdf_generator_test.exs
@@ -15,13 +15,13 @@ defmodule PdfGeneratorTest do
     file_info = File.stat! temp_filename
     assert file_info.size > 0
     pdf = File.read! temp_filename
-    
+
     # PDF header should be present
     assert String.slice( pdf, 0, 6) == "%PDF-1"
   end
 
   test "command prefix with noop env" do
-    {:ok, temp_filename } = PdfGenerator.generate @html, [ command_prefix: "env" ]
+    {:ok, _temp_filename } = PdfGenerator.generate @html, [ command_prefix: "env" ]
   end
 
 end


### PR DESCRIPTION
# New in 0.3.4

  - 0.3.4
    - BUGFIX: fix merge confusion to **really** support `xvfb-run` or other
      command prefixes to wkhtmltopdf
    - support explicit deletion of temporary files thanks to
      [Edipo Vinicius da Silva](https://github.com/edipox)
    - Improve README
