### PR TITLE
Add misc_random to applications list

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule PdfGenerator.Mixfile do
   # Type `mix help compile.app` for more information
   def application do
     [
-      applications: [ :logger, :porcelain ],
+      applications: [ :logger, :porcelain, :misc_random ],
       mod: { PdfGenerator, [] }
     ]
   end


### PR DESCRIPTION
Hey,

I had some problems building a release with this library as dependency. Adding misc_random to included applications list fixed this.

More specifically, the error was the following:
```
==> One or more direct or transitive dependencies are missing from
    :applications or :included_applications, they will not be included
    in the release:

    :misc_random

    This can cause your application to fail at runtime. If you are sure
    that this is not an issue, you may ignore this warning.
```