### PR TITLE
Support command prefix with args

### DIFF
--- a/lib/pdf_generator.ex
+++ b/lib/pdf_generator.ex
@@ -160,6 +160,9 @@ defmodule PdfGenerator do
   def make_command_tuple(_command_prefix = nil, wkhtml_executable, arguments) do
     { wkhtml_executable, arguments }
   end
+  def make_command_tuple([command_prefix | args], wkhtml_executable, arguments) do
+    { command_prefix, args ++ [wkhtml_executable] ++ arguments }
+  end
   def make_command_tuple(command_prefix, wkhtml_executable, arguments) do
     { command_prefix, [wkhtml_executable] ++ arguments }
   end

--- a/test/pdf_generator_test.exs
+++ b/test/pdf_generator_test.exs
@@ -23,6 +23,10 @@ defmodule PdfGeneratorTest do
     {:ok, _temp_filename } = PdfGenerator.generate @html, command_prefix: "env"
   end
 
+  test "command prefix with args with noop env" do
+    {:ok, _temp_filename } = PdfGenerator.generate @html, command_prefix: ["env", "foo=bar"]
+  end
+
   test "generate_binary reads file" do
     assert {:ok, "%PDF-1" <> _pdf} = @html |> PdfGenerator.generate_binary
   end


### PR DESCRIPTION
Allows the ability to supply args to the command prefix by specifying command prefix as a list
```
config :pdf_generator,
  command_prefix: ["xvfb-run", "-a"]
```