### PR TITLE
Adding in raise_on_missing_wkhtmltopdf_binary config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,22 @@
 # Changes
-
+  - 0.3.6
+    - bumped dependencies:
+      * porcelain 2.0.3 to support newer erlangs and remove warnings
+      * ex_doc 0.16 to remove warnings, remove from runtime
+      * removed explixit earmark
+    - add option to pick output pdf filename, thanks
+      to [praveenperera](https://github.com/praveenperera)
+    - improved README on heroku, corrected typos. Thanks
+      to [jbhatab](https://github.com/jbhatab)
+      and [maggy96](https://github.com/maggy96)
+  - 0.3.5
+    - add `generate_binary` and `generate_binary!` that immediately return the
+      PDF binary instead of an `{:ok, filename}` tuple.
+    - add `generate!` to immediately return the filename
+    - some more tests
+    - minor change `delete_temporary` must be truthy. (the old supported value
+      `:html` will still work) and will delete both intermediate HTML And PDF
+      files in `generate_binary` and `generate_binary!`
   - 0.3.5
     - add `generate_binary` and `generate_binary!` that immediately return the
       PDF binary instead of an `{:ok, filename}` tuple.

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,5 @@
 use Mix.Config
 
 config :pdf_generator,
-  command_prefix: "xvfb-run"
-
-
+  command_prefix: "xvfb-run",
+  raise_on_missing_wkhtmltopdf_binary: true

--- a/lib/pdf_generator.ex
+++ b/lib/pdf_generator.ex
@@ -1,6 +1,6 @@
 defmodule PdfGenerator do
 
-  @vsn "0.3.5"
+  @vsn "0.3.6"
 
   @moduledoc """
   # PdfGenerator
@@ -67,8 +67,9 @@ defmodule PdfGenerator do
         # worker(TestApp.Worker, [arg1, arg2, arg3])
         worker(
           PdfGenerator.PathAgent, [[
-            wkhtml_path:    Application.get_env(:pdf_generator, :wkhtml_path),
-            pdftk_path:     Application.get_env(:pdf_generator, :pdftk_path),
+            wkhtml_path:                         Application.get_env(:pdf_generator, :wkhtml_path),
+            pdftk_path:                          Application.get_env(:pdf_generator, :pdftk_path),
+            raise_on_missing_wkhtmltopdf_binary: Application.get_env(:pdf_generator, :raise_on_missing_wkhtmltopdf_binary, true),
           ]]
         )
       ]

--- a/lib/pdf_generator_path_agent.ex
+++ b/lib/pdf_generator_path_agent.ex
@@ -23,7 +23,6 @@ defmodule PdfGenerator.PathAgent do
       ++ paths_from_options
       |> Enum.dedup()
       |> Enum.filter( fn { _, v } -> v != nil end )
-      |> IO.inspect
       |> raise_or_continue()
 
     Map.merge %PdfGenerator.PathAgent{}, Enum.into( options, %{} )

--- a/lib/pdf_generator_path_agent.ex
+++ b/lib/pdf_generator_path_agent.ex
@@ -1,5 +1,5 @@
 defmodule PdfGenerator.PathAgent do
-
+  require Logger
   defstruct wkhtml_path: nil, pdftk_path: nil
 
   @moduledoc """
@@ -17,20 +17,16 @@ defmodule PdfGenerator.PathAgent do
     # options override system default paths
     options =
       [
-        wkhtml_path:    System.find_executable( "wkhtmltopdf" ),
+        wkhtml_path:    System.find_executable( "wkhtsmltopdf" ),
         pdftk_path:     System.find_executable( "pdftk" )
       ]
       ++ paths_from_options
+      |> Enum.dedup()
       |> Enum.filter( fn { _, v } -> v != nil end )
+      |> IO.inspect
+      |> raise_or_continue()
 
-    # at least, wkhtmltopdf executable sould be there
-    if Keyword.fetch!( options, :wkhtml_path ) == nil do
-      raise "path to wkhtmltopdf is neither found on path nor given as wkhtml_path option. Can't continue."
-    end
-
-    # IO.inspect options
     Map.merge %PdfGenerator.PathAgent{}, Enum.into( options, %{} )
-
   end
 
   @doc "Stops agent, returns :ok"
@@ -43,4 +39,16 @@ defmodule PdfGenerator.PathAgent do
     Agent.get( @name, fn( data ) -> data end )
   end
 
+  def raise_or_continue(options) do
+    exe_exists       = File.exists?(Keyword.get(options, :wkhtml_path, ""))
+    raise_on_missing = Keyword.get(options, :raise_on_missing_wkhtmltopdf_binary, true)
+
+    case {exe_exists, raise_on_missing} do
+      {true, _} -> options
+      {false, true} -> raise "wkhtmltopdf executable was not found on your system"
+      {false, false} -> 
+        Logger.warn "wkhtmltopdf executable was not found on your system"
+        options
+    end
+  end
 end

--- a/lib/pdf_generator_path_agent.ex
+++ b/lib/pdf_generator_path_agent.ex
@@ -17,7 +17,7 @@ defmodule PdfGenerator.PathAgent do
     # options override system default paths
     options =
       [
-        wkhtml_path:    System.find_executable( "wkhtsmltopdf" ),
+        wkhtml_path:    System.find_executable( "wkhtmltopdf" ),
         pdftk_path:     System.find_executable( "pdftk" )
       ]
       ++ paths_from_options


### PR DESCRIPTION
Addresses #22 

raise_on_missing_wkhtmltopdf_binary is needed additionally for CI environments where you might mock out your pdf generation but the agent will not start unless wkhtmltopdf exists.

