### PR TITLE
Remove misc_random dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 erl_crash.dump
 *.ez
 /doc
-
+.elixir_ls

--- a/README.md
+++ b/README.md
@@ -141,25 +141,3 @@ Elixir and Phoenix buildpacks first.
 
 For more info, read the [docs on hex](http://hexdocs.pm/pdf_generator) or issue
 `h PdfGenerator` in your iex shell.
-
-# Common issues
-
-## Running from within distillery or exrm releases
-
-**ERROR** 
-
-`(UndefinedFunctionError) function Misc.Random.string/0 is undefined (module Misc.Random is not available)`
-
-**FIX**
-
-For now, unfortunately, it's required to add `misc_random` to either your
-`included_applications` section in your `mix.exs` (exrm) or for (distillery) add
-it to your release/applications list in `rel/config.exs`.
-
-```
-...
-release :your_app do
-  set version: current_version(:your_app)
-  set applications: [:misc_random]
-end
-```

--- a/lib/pdf_generator.ex
+++ b/lib/pdf_generator.ex
@@ -79,7 +79,6 @@ defmodule PdfGenerator do
   end
 
   # return file name of generated pdf
-  # requires: Porcelain, Misc.Random
 
   @doc """
   Generates a pdf file from given html string. Returns a string containing a
@@ -168,12 +167,12 @@ defmodule PdfGenerator do
     { command_prefix, [wkhtml_executable] ++ arguments }
   end
 
-  defp generate_filebase(nil), do: generate_filebase(Misc.Random.string)
+  defp generate_filebase(nil), do: generate_filebase(PdfGenerator.Random.string())
   defp generate_filebase(filename), do: Path.join(System.tmp_dir, filename)
 
   def encrypt_pdf( pdf_input_path, user_pw, owner_pw ) do
     pdftk_path = PdfGenerator.PathAgent.get.pdftk_path
-    pdf_output_file  = Path.join System.tmp_dir, Misc.Random.string <> ".pdf"
+    pdf_output_file  = Path.join System.tmp_dir, PdfGenerator.Random.string() <> ".pdf"
 
     %Result{ out: _output, status: status } = Porcelain.exec(
       pdftk_path, [
@@ -192,7 +191,7 @@ defmodule PdfGenerator do
     end
   end
 
-  defp random_if_undef(nil), do: Misc.Random.string(16)
+  defp random_if_undef(nil), do: PdfGenerator.Random.string(16)
   defp random_if_undef(any), do: any
 
   @doc """

--- a/lib/pdf_generator/random.ex
+++ b/lib/pdf_generator/random.ex
@@ -1,0 +1,7 @@
+defmodule PdfGenerator.Random do
+  @chars "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" |> String.codepoints()
+
+  def string(length \\ 8) do
+    Enum.map_join(1..length, fn _ -> Enum.random(@chars) end)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule PdfGenerator.Mixfile do
       app: :pdf_generator,
       name: "PDF Generator",
       version: "0.3.7",
-      elixir: ">= 1.0.0",
+      elixir: ">= 1.1.0",
       deps: deps(),
       description: description(),
       package: package(),
@@ -47,8 +47,6 @@ defmodule PdfGenerator.Mixfile do
     [
         # communication with external programs
         {:porcelain, "~> 2.0"},
-        # a helper
-        {:misc_random, ">=0.2.6" },
         # generate docs
         {:ex_doc, "~> 0.16", only: :dev, runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,5 @@
-%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
+%{
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "misc_random": {:hex, :misc_random, "0.2.6", "959981142c96005731ed8b7df2440f5563a31c3a159edd5769fe28c77e3e0af7", [:mix], []},
   "porcelain": {:hex, :porcelain, "2.0.3", "2d77b17d1f21fed875b8c5ecba72a01533db2013bd2e5e62c6d286c029150fdc", [:mix], []},
-  "random": {:git, "https://github.com/gutschilla/elixir-helper-random.git", "fb801765651e8e6fa02866803592eade96b6c4d7", []},
-  "zarex": {:hex, :zarex, "0.3.0", "e19145de2127671f3d3f4bdb6bb60a0d70830836a01a79ba63428a5bbe3a16e0", [:mix], []}}
+}

--- a/test/pdf_generator/random_test.exs
+++ b/test/pdf_generator/random_test.exs
@@ -1,0 +1,19 @@
+defmodule PdfGenerator.RandomTest do
+  use ExUnit.Case
+
+  describe "string/0" do
+    test "returns an 8 length random string" do
+      string = PdfGenerator.Random.string()
+      assert String.valid?(string)
+      assert String.length(string) == 8
+    end
+  end
+
+  describe "string/1" do
+    test "returns a random string with the given lenght" do
+      string = PdfGenerator.Random.string(99)
+      assert String.valid?(string)
+      assert String.length(string) == 99
+    end
+  end
+end


### PR DESCRIPTION
This is related with issue #42.

With this change we avoid the problem on distillery and exrm. Also, we need elixir >= [1.1.0](https://github.com/elixir-lang/elixir/releases/tag/v1.1.0), to be able to use `Enum.random`.