### PR TITLE
Document `prefer_system_executable` for chrome-headless

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,13 @@ config :pdf_generator,
     pdftk_path:     "/usr/bin/pdftk"          # <-- only needed for PDF encryption
 ```
 
-or, if you prefer shrome-headless
+or, if you prefer chrome-headless
 
 ```
 config :pdf_generator,
-    use_chrome: true,                          # <-- make sure you installed node/puppetteer
-    raise_on_missing_wkhtmltopdf_binary: false # <-- so the app won't complain about a missing wkhtmltopdf
+    use_chrome: true,                           # <-- make sure you installed node/puppeteer
+    prefer_system_executable: true              # <-- set this if you installed the NPM dependencies globally
+    raise_on_missing_wkhtmltopdf_binary: false, # <-- so the app won't complain about a missing wkhtmltopdf
 ```
 
 ## More options


### PR DESCRIPTION
The recommended setup instructions for chrome-headless, which tell the user to install the dependencies globally using `npm -g install`, only work if we set `prefer_system_executable: true` in the generator options.

This should definitely be mentioned in the docs, as it currently requires digging through the code to find this line: https://github.com/gutschilla/elixir-pdf-generator/blob/master/lib/pdf_generator.ex#L184