### PR TITLE
Remove specific env config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,5 +8,8 @@ config :pdf_generator,
   # allow chrome to run as root
   disable_chrome_sandbox: true
 
-import_config "#{Mix.env}.exs"
-
+if Mix.env() == :test do
+  config :pdf_generator,
+    command_prefix: "xvfb-run",
+    raise_on_missing_wkhtmltopdf_binary: true
+end

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,2 +1,0 @@
-use Mix.Config
-

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,2 +1,0 @@
-use Mix.Config
-

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,0 @@
-use Mix.Config
-
-config :pdf_generator,
-  command_prefix: "xvfb-run",
-  raise_on_missing_wkhtmltopdf_binary: true


### PR DESCRIPTION
Hey, thanks for this handy library that's been helping me on generating PDFs.

This fixes compiling non-default environments (such as sandbox, staging). It was causing `Code.LoadError` when trying to find `/app/deps/pdf_generator/config/staging.exs` (in my case, I was running `mix deps.compile` on my staging environment)

<img width="719" alt="image" src="https://user-images.githubusercontent.com/5093045/90241785-1f9e7280-de02-11ea-8e49-23b6cde66a8a.png">

I have checked some other Elixir libraries and I tried a similar approach of not storing a specific config file for each environment, but only a `config.exs`, or none.

* https://github.com/ueberauth/guardian/tree/master/config
* https://github.com/phoenixframework/phoenix/tree/master/config