### PR TITLE
Use new Supervisor syntax for elixir version >= 1.5

### DIFF
--- a/lib/pdf_generator.ex
+++ b/lib/pdf_generator.ex
@@ -60,15 +60,14 @@ defmodule PdfGenerator do
       import Supervisor.Spec, warn: false
 
       children = [
-        # Define workers and child supervisors to be supervised
-        # worker(TestApp.Worker, [arg1, arg2, arg3])
-        worker(
-          PdfGenerator.PathAgent, [[
+        %{
+          id: PdfGenerator.PathAgent,
+          start: {PdfGenerator.PathAgent, :start_link, [[
             wkhtml_path:                         Application.get_env(:pdf_generator, :wkhtml_path),
             pdftk_path:                          Application.get_env(:pdf_generator, :pdftk_path),
             raise_on_missing_wkhtmltopdf_binary: Application.get_env(:pdf_generator, :raise_on_missing_wkhtmltopdf_binary, true),
-          ]]
-        )
+          ]]}
+        }
       ]
 
       opts = [strategy: :one_for_one, name: PdfGenerator.Supervisor]

--- a/mix.exs
+++ b/mix.exs
@@ -5,8 +5,8 @@ defmodule PdfGenerator.Mixfile do
     [
       app: :pdf_generator,
       name: "PDF Generator",
-      version: "0.6.2",
-      elixir: ">= 1.1.0",
+      version: "0.6.3",
+      elixir: ">= 1.5.0",
       deps: deps(),
       description: description(),
       package: package(),


### PR DESCRIPTION
Hello,

I came across an issue where, after upgrading to elixir 1.11, I saw that pdf_generator.ex was still using the deprecated syntax for Supervisor.spec.worker.

I made the change to use the new child specification syntax that is applicable for elixir versions 1.5 and above.

If anything is out of place or not the best practice, I would really appreciate it if you let me know, as I'm a newbie in the open source/elixir world. 

Thank you very much!

Dongkeun