### PR TITLE
added weasyprint as another pdf generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ Or, run `cd priv && npm install`
   For other distributions, refer to http://wkhtmltopdf.org/downloads.html – For
   example, replace `bionic` with `xenial` if you're on Ubuntu 16.04.
 
+### weasyprint
+
+  for installation instructions visit https://doc.courtbouillon.org/weasyprint/stable/first_steps.html
+
 ## Optional Dependencies
 
 3. _optional:_ Install `xvfb` (shouldn't be required with the binary mentioned above):

--- a/lib/pdf_generator_path_agent.ex
+++ b/lib/pdf_generator_path_agent.ex
@@ -5,6 +5,7 @@ defmodule PdfGenerator.PathAgent do
     pdftk_path:  nil,
     chrome_path: nil,
     node_path:   nil,
+    weasyprint_path: nil
   ]
 
   @moduledoc """
@@ -30,6 +31,7 @@ defmodule PdfGenerator.PathAgent do
         pdftk_path:  System.find_executable("pdftk"),
         chrome_path: System.find_executable("chrome-headless-render-pdf"),
         node_path:   System.find_executable("nodejs") || System.find_executable("node"),
+        weasyprint_path: System.find_executable("weasyprint"),
       ]
       ++ paths_from_options
       |> Enum.dedup()

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule PdfGenerator.Mixfile do
   defp package do
     [
       description:
-        "A wrapper for wkhtmltopdf and chrome-headless (puppeteer) with optional " <>
+        "A wrapper for wkhtmltopdf, weasyprint and chrome-headless (puppeteer) with optional " <>
           "support for encryption via pdftk.",
       files: ["lib", "mix.exs", "README.md", "LICENSE", "test", "priv"],
       maintainers: ["Martin Gutsch"],


### PR DESCRIPTION
Hey all,

hope this is not unwelcome, I was working on a pdf generation project and I was using your library. 
However I noticed multiple issues with wkhtmltopdf and headless chrome, and I decided to evaluate weasyprint. 
Well, since your library handles the overhead of including that really well and the code was easy to understand I took the liberty of just implementing the feature.
I realize that I did not put sufficient documentation for it yet as I wouldn't want to get into it if this addition is unwanted, but the funcitonality is working as intended.
Please check it out, I think its a very simple and at the same time impactful addition to your project.

Best